### PR TITLE
bigfeta: fix str/byte error

### DIFF
--- a/bigfeta/bigfeta.py
+++ b/bigfeta/bigfeta.py
@@ -328,6 +328,8 @@ class BigFeta(argschema.ArgSchemaParser):
                 results = json.loads(f.get('results')[()][0].decode('utf-8'))
 
             r = f.get('resolved_tiles')[()][0]
+            r = (r.decode() if not isinstance(r, str) else r)
+
             rname = os.path.join(
                     os.path.dirname(filename),
                     r)


### PR DESCRIPTION
There was an error in python 3.6+ in the petsc tests (see dev and main branch)-- I'd guess this is a version issue of some library, but this little change makes tests pass.