### PR TITLE
Fixedtile ra

### DIFF
--- a/bigfeta/bigfeta.py
+++ b/bigfeta/bigfeta.py
@@ -200,7 +200,7 @@ def create_CSR_A_fromobjects(
         transform_apply, regularization_dict, matrix_assembly_dict,
         order=2, fullsize=False,
         return_draft_resolvedtiles=False, copy_resolvedtiles=True,
-        results_in_chunks=False):
+        results_in_chunks=False, tiles_prepared=False):
     """Assembles results as in BigFeta.create_CSR_A from
         resolvedtiles and pointmatches
 
@@ -229,6 +229,9 @@ def create_CSR_A_fromobjects(
     results_in_chunks : boolean
         whether to return another dicitonary item "A_weights_rhs_z_chunks"
         with chunked results (for writing to hdf5)
+    tiles_prepared : boolean
+        whether tile transformations are prepared ahead to time.
+        If True will not append transform based on input parameters.
 
     Returns
     -------
@@ -242,10 +245,10 @@ def create_CSR_A_fromobjects(
 
     draft_resolvedtiles = (
         copy.deepcopy(resolvedtiles) if copy_resolvedtiles else resolvedtiles)
-
-    utils.ready_transforms(
-        draft_resolvedtiles.tilespecs, transform_name,
-        fullsize, order)
+    if not tiles_prepared:
+        utils.ready_transforms(
+            draft_resolvedtiles.tilespecs, transform_name,
+            fullsize, order)
 
     # this emulates the pre_load behavior of the schema
     depth = (

--- a/bigfeta/transform/utils.py
+++ b/bigfeta/transform/utils.py
@@ -32,3 +32,19 @@ def aff_matrix(theta, offs=None):
     M[0, 2] = offs[0]
     M[1, 2] = offs[1]
     return M
+
+
+def aff_matrices(thetas, offs=None):
+    """affine matrices from thetas
+    """
+    c, s = np.cos(thetas), np.sin(thetas)
+    matrices = np.zeros((len(thetas), 3, 3))
+
+    matrices[:, 0, 0] = c
+    matrices[:, 0, 1] = -s
+    matrices[:, 1, 0] = s
+    matrices[:, 1, 1] = c
+    if offs is None:
+        return matrices[:, :-1, :-1]
+    matrices[:, :, -1] = np.insert(offs, offs.shape[1], 1, 1)
+    return matrices


### PR DESCRIPTION
optionally allow pre-defined tilespecs, meaning that you can input transformed matches and tilespecs with AlignerTransforms to allow more flexible A creation.  Also includes faster rotation model with vectorized affine matrix from theta generation.
This is the codebase I have been using for redoing rough alignment (i.e. solving with some tiles remaining in place and others aligning to them)