### PR TITLE
faster rotationmodel

### DIFF
--- a/bigfeta/transform/rotation_model.py
+++ b/bigfeta/transform/rotation_model.py
@@ -154,9 +154,6 @@ class AlignerRotationModel(renderapi.transform.AffineModel):
         qcm = qpts - qpts.mean(axis=0)
 
         # points very close to center of mass are noisy
-        # rfilter = np.argwhere(
-        #         (np.linalg.norm(pcm, axis=1) > 15) &
-        #         (np.linalg.norm(qcm, axis=1) > 15)).flatten()
         rfilter = ((np.linalg.norm(pcm, axis=1) > 15) &
                    (np.linalg.norm(qcm, axis=1) > 15))
         pcm = pcm[rfilter]
@@ -166,7 +163,6 @@ class AlignerRotationModel(renderapi.transform.AffineModel):
         pangs = np.arctan2(pcm[:, 1], pcm[:, 0])
 
         # rotate all the q values relative to p
-        # ams = block_diag(*[aff_matrix(-i) for i in pangs])
         ams = block_diag(*aff_matrices(-1. * pangs))
         qrot = ams.dot(qcm.flatten()).reshape(-1, 2)
 

--- a/bigfeta/transform/utils.py
+++ b/bigfeta/transform/utils.py
@@ -32,3 +32,19 @@ def aff_matrix(theta, offs=None):
     M[0, 2] = offs[0]
     M[1, 2] = offs[1]
     return M
+
+
+def aff_matrices(thetas, offs=None):
+    """affine matrices from thetas
+    """
+    c, s = np.cos(thetas), np.sin(thetas)
+    matrices = np.zeros((len(thetas), 3, 3))
+
+    matrices[:, 0, 0] = c
+    matrices[:, 0, 1] = -s
+    matrices[:, 1, 0] = s
+    matrices[:, 1, 1] = c
+    if offs is None:
+        return matrices[:, :-1, :-1]
+    matrices[:, :, -1] = np.insert(offs, offs.shape[1], 1, 1)
+    return matrices

--- a/bigfeta/utils.py
+++ b/bigfeta/utils.py
@@ -843,7 +843,6 @@ def blocks_from_tilespec_pair(
     if not any(match["matches"]["w"]):
         return None, None, None, None
 
-
     if len(match['matches']['w']) < matrix_assembly['npts_min']:
         return None, None, None, None
 
@@ -852,7 +851,9 @@ def blocks_from_tilespec_pair(
     w = np.array(match['matches']['w'])
 
     if isinstance(ptspec.tforms[-1], AlignerRotationModel):
-        ppts, qpts, w = AlignerRotationModel.preprocess(ppts, qpts, w)
+        ppts, qpts, w = AlignerRotationModel.preprocess(
+            ppts, qpts, w, matrix_assembly['npts_max'],
+            matrix_assembly['choose_random'])
 
     if ppts.shape[0] > matrix_assembly['npts_max']:
         if matrix_assembly['choose_random']:


### PR DESCRIPTION
implements changes mentioned in #14 to reduce time building A for RotationModels.  I ran this on two large rough alignments in a test environment and saw one go from 20 minutes to 1 min and another from 100 mins to 1.5 mins.