### PR TITLE
travis: remove python 3.5, add 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ dist: xenial
 python:
 # we don't actually use travis python versions, so match these to conda
 - '2.7'
-- '3.5'
 - '3.6'
 - '3.7'
+- '3.8'
 services:
 - docker
 addons:


### PR DESCRIPTION
python 3.5 has problems with testing.