### PR TITLE
pyproject: change setuptools keyword

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ requires = ["setuptools>=64", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-py-modules = [
+packages = [
     "bigfeta"
 ]
 


### PR DESCRIPTION
Should fix build for wheels.  upcoming new release (v1.1.4) should be a viable substitute for v1.1.3.